### PR TITLE
fix: Use PAT to manage hombrew-taps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAPS_PAT: ${{ secrets.HOMEBREW_TAPS_PAT }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ brews:
   - repository:
       owner: "kevinrobayna"
       name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.HOMEBREW_TAPS_PAT }}"
     commit_author:
       name: "Kevin Robayna"
       email: "me@kevinrobayna.com"


### PR DESCRIPTION
Apparenty i can't use the github token for this (makes sense)