### PR TITLE
fix: Ensure day is always 2 digits

### DIFF
--- a/cmd/aoc2md/main.go
+++ b/cmd/aoc2md/main.go
@@ -88,7 +88,7 @@ func main() {
 				return nil
 			}
 
-			path := filepath.Join(fmt.Sprint(year), fmt.Sprintf("day-%01d", day))
+			path := filepath.Join(fmt.Sprint(year), fmt.Sprintf("day-%02d", day))
 			err := os.MkdirAll(path, os.ModePerm)
 			if err != nil {
 				slog.Error("Error creating folder", "err", err)


### PR DESCRIPTION
This is the way I always intended for this to behave. This makes the file to be reliable independently of the day